### PR TITLE
Fix LK23M OLED config and update BootMagic key

### DIFF
--- a/keyboards/lambdakb/lk23m/config.h
+++ b/keyboards/lambdakb/lk23m/config.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #define OLED_DISPLAY_128X32
+#define OLED_BRIGHTNESS 48
+#define OLED_UPDATE_INTERVAL 100
 #define OLED_FONT_H "lib/glcdfont.c"
 
 #define RP2040_BOOTLOADER_DOUBLE_TAP_RESET

--- a/keyboards/lambdakb/lk23m/keyboard.json
+++ b/keyboards/lambdakb/lk23m/keyboard.json
@@ -29,9 +29,12 @@
     },
     "encoder": {
         "rotary": [
-            {"pin_a": "GP4", "pin_b": "GP5", "resolution": 4},
-            {"pin_a": "GP28", "pin_b": "GP29", "resolution": 4}
+            {"pin_a": "GP4", "pin_b": "GP5", "resolution": 2},
+            {"pin_a": "GP28", "pin_b": "GP29", "resolution": 2}
         ]
+    },
+    "bootmagic": {
+        "matrix": [4, 3]
     },
     "layouts": {
         "LAYOUT_numpad_6x4": {
@@ -61,6 +64,9 @@
                 {"matrix": [4, 3], "x": 3, "y": 4.25, "h": 2}
             ]
         }
+    },
+    "dynamic_keymap": {
+        "layer_count": 4
     },
     "keycodes": [
         {"key": "KC_DBL0", "label": "Double 0 key", "aliases": ["DBL0"]}


### PR DESCRIPTION
Fix OLED processing by adding update interval & update bootmagic key to use the "Enter" key instead of `[0,0]` (Esc / Encoder) for ease of use.